### PR TITLE
Fix unsafe global REALPATH_BUF in realpath_lua

### DIFF
--- a/src/realpath.c
+++ b/src/realpath.c
@@ -24,21 +24,66 @@
 #include "lua_realpath.h"
 // std
 #include <limits.h>
+#include <stdlib.h>
 
-static size_t REALPATH_BUFSIZ = PATH_MAX;
-static char *REALPATH_BUF     = NULL;
+#define REALPATH_GC_MT "realpath.gc"
+
+static inline void update_gcvar(void **gcvar, void *ref)
+{
+    if (*gcvar) {
+        free(*gcvar);
+    }
+    *gcvar = ref;
+}
+
+// __gc metamethod for the GC guard userdata
+static int gc_lua(lua_State *L)
+{
+    update_gcvar((void **)lua_touserdata(L, 1), NULL);
+    return 0;
+}
+
+static inline void **new_gcvar(lua_State *L)
+{
+    void **gcvar = (void **)lua_newuserdata(L, sizeof(void *));
+    *gcvar       = NULL;
+    lauxh_setmetatable(L, REALPATH_GC_MT);
+    return gcvar;
+}
+
+static inline void init_gcmt(lua_State *L)
+{
+    // register the GC guard metatable used for the NULL buf case
+    if (luaL_newmetatable(L, REALPATH_GC_MT)) {
+        lua_pushcfunction(L, gc_lua);
+        lua_setfield(L, -2, "__gc");
+    }
+    lua_pop(L, 1);
+}
 
 static int realpath_lua(lua_State *L)
 {
-    size_t len       = 0;
-    const char *path = lauxh_checklstring(L, 1, &len);
-    int normalize    = lauxh_optboolean(L, 2, 0);
-    int resolve      = lauxh_optboolean(L, 3, 1);
+    size_t len         = 0;
+    const char *path   = lauxh_checklstring(L, 1, &len);
+    int normalize      = lauxh_optboolean(L, 2, 0);
+    int resolve        = lauxh_optboolean(L, 3, 1);
+    size_t pathbuf_siz = (size_t)lua_tointeger(L, lua_upvalueindex(1));
+    // buf is NULL when _PC_PATH_MAX is indeterminate; realpath(3) will malloc
+    char *buf          = lua_touserdata(L, lua_upvalueindex(2));
+    void **gcvar       = NULL;
 
     lua_settop(L, 1);
-    // perform normalization only
+    // perform normalization only (does not use the path buffer)
     if (!resolve) {
         return lua_realpath_normalize(L, (char *)path, len);
+    }
+
+    // when a pre-allocated buffer is available, check the input length
+    if (buf && len > pathbuf_siz) {
+        lua_pushnil(L);
+        errno = ENAMETOOLONG;
+        lua_errno_new(L, errno, "realpath");
+        return 2;
     }
 
     // perform normalization before resolving the path
@@ -47,18 +92,40 @@ static int realpath_lua(lua_State *L)
         if (rv != 1) {
             return rv;
         }
+        // 'path' now points to the normalized Lua string on the stack
         path = lua_tostring(L, -1);
     }
 
+    // for the NULL buf case, push a GC guard onto the stack before calling
+    // realpath(3) so that the malloc'd result is freed even if lua_pushstring
+    // throws an OOM error: the guard stays alive on the stack during the
+    // pushstring call, and its __gc finalizer calls free() if unwound by
+    // longjmp
+    if (!buf) {
+        gcvar = new_gcvar(L);
+    }
+
     // perform path resolution
-    path = realpath(path, REALPATH_BUF);
-    lua_settop(L, 0);
+    // if buf is NULL, realpath(3) allocates the output buffer with malloc(3)
+    path = realpath(path, buf);
     if (path) {
+        if (buf) {
+            // pre-allocated buffer: resolved == buf, no free needed
+            lua_settop(L, 0);
+            lua_pushstring(L, path);
+            return 1;
+        }
+
+        // arm the GC guard while it is still live on the stack so that
+        // lua_pushstring is covered: if it throws OOM, __gc frees resolved
+        update_gcvar(gcvar, (void *)path);
         lua_pushstring(L, path);
+        // pushstring succeeded: free immediately and disarm the guard
+        update_gcvar(gcvar, NULL);
         return 1;
     }
 
-    // got error
+    lua_settop(L, 0);
     lua_pushnil(L);
     lua_errno_new(L, errno, "realpath");
     return 2;
@@ -70,16 +137,22 @@ LUALIB_API int luaopen_realpath(lua_State *L)
 
     lua_errno_loadlib(L);
 
-    // set the maximum number of bytes in a pathname
-    if (pathmax != -1) {
-        REALPATH_BUFSIZ = pathmax;
-    }
-    // allocate the buffer for realpath
-    REALPATH_BUF = lua_newuserdata(L, REALPATH_BUFSIZ);
-    // holds until the state closes
-    luaL_ref(L, LUA_REGISTRYINDEX);
+    // register the GC guard metatable used for the NULL buf case
+    init_gcmt(L);
 
-    lua_pushcfunction(L, realpath_lua);
+    if (pathmax != -1) {
+        size_t pathbuf_siz = (size_t)pathmax;
+        // upvalue 1: path buffer size
+        lua_pushinteger(L, (lua_Integer)pathbuf_siz);
+        // upvalue 2: path buffer (held by closure until state closes)
+        lua_newuserdata(L, pathbuf_siz);
+    } else {
+        // _PC_PATH_MAX is indeterminate: realpath(3) will allocate dynamically
+        lua_pushinteger(L, 0); // upvalue 1: no size limit to check
+        lua_pushlightuserdata(
+            L, NULL); // upvalue 2: NULL signals dynamic allocation
+    }
+    lua_pushcclosure(L, realpath_lua, 2);
 
     return 1;
 }

--- a/test/realpath_test.lua
+++ b/test/realpath_test.lua
@@ -25,6 +25,11 @@ local function test_realpath_resolve()
     assert.is_nil(pathname);
     assert.equal(err.type, errno.EILSEQ)
 
+    -- test that return ENAMETOOLONG error
+    pathname, err = realpath(string.rep('x', 65536))
+    assert.is_nil(pathname)
+    assert.equal(err.type, errno.ENAMETOOLONG)
+
     -- test that returns error
     pathname, err = realpath('./foo/../bar/../realpath_test.lua/')
     assert.is_nil(pathname)


### PR DESCRIPTION
This pull request refactors the memory management for path resolution in `src/realpath.c`, improving safety and correctness when handling buffers for the `realpath` function. The main changes introduce a garbage-collected guard for dynamically allocated buffers, ensuring proper cleanup even in the case of Lua errors, and restructure how the buffer and its size are managed.

### Memory management improvements

* Introduced a GC guard mechanism using a Lua userdata with a `__gc` metamethod to ensure that memory allocated by `realpath` is always freed, even if Lua throws an error during stack operations. (`src/realpath.c`)
* Added helper functions (`update_gcvar`, `new_gcvar`, `init_gcmt`, and `gc_lua`) to manage the lifecycle and registration of the GC guard. (`src/realpath.c`)

### Buffer and upvalue handling

* Changed the way the path buffer and its size are passed to `realpath_lua`: these are now provided as closure upvalues, allowing for both statically and dynamically allocated buffers, and enabling explicit length checks when a buffer is pre-allocated. (`src/realpath.c`)
* Updated the logic to handle the case where `_PC_PATH_MAX` is indeterminate, using `NULL` to signal dynamic allocation and a GC guard to ensure cleanup. (`src/realpath.c`)

### Error handling and safety

* Ensured that errors such as path length exceeding the buffer size or out-of-memory conditions are handled gracefully, with all allocated resources properly released. (`src/realpath.c`)

These changes make the module safer and more robust, especially in edge cases involving dynamic memory allocation and Lua error handling.