### PR TITLE
Clean up header includes in src files

### DIFF
--- a/src/lua_realpath.h
+++ b/src/lua_realpath.h
@@ -24,13 +24,11 @@
 #define lua_realpath_h
 
 #include <errno.h>
-#include <fcntl.h>
-#include <stdio.h>
-#include <string.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <unistd.h>
+#include <stdint.h>
 // lua
+#include <lauxlib.h>
+#include <lua.h>
+// external headers
 #include <lua_errno.h>
 
 static inline int lua_realpath_normalize(lua_State *L, char *path, size_t len)

--- a/src/normalize.c
+++ b/src/normalize.c
@@ -22,6 +22,8 @@
 
 // lua
 #include "lua_realpath.h"
+// external headers
+#include "lauxhlib.h"
 
 static int normalize_lua(lua_State *L)
 {

--- a/src/realpath.c
+++ b/src/realpath.c
@@ -20,11 +20,13 @@
  *  DEALINGS IN THE SOFTWARE.
  */
 
+// std
+#include <stdlib.h>
+#include <unistd.h>
 // lua
 #include "lua_realpath.h"
-// std
-#include <limits.h>
-#include <stdlib.h>
+// external headers
+#include "lauxhlib.h"
 
 #define REALPATH_GC_MT "realpath.gc"
 
@@ -148,9 +150,10 @@ LUALIB_API int luaopen_realpath(lua_State *L)
         lua_newuserdata(L, pathbuf_siz);
     } else {
         // _PC_PATH_MAX is indeterminate: realpath(3) will allocate dynamically
-        lua_pushinteger(L, 0); // upvalue 1: no size limit to check
-        lua_pushlightuserdata(
-            L, NULL); // upvalue 2: NULL signals dynamic allocation
+        // upvalue 1: no size limit to check
+        lua_pushinteger(L, 0);
+        // upvalue 2: NULL signals dynamic allocation
+        lua_pushlightuserdata(L, NULL);
     }
     lua_pushcclosure(L, realpath_lua, 2);
 


### PR DESCRIPTION
This pull request reorganizes and cleans up the header inclusions and dependencies across several source files, improving consistency and clarity in how external and Lua-specific headers are included. It also makes minor improvements to code comments and structure for better maintainability.

Header inclusion and dependency organization:

* Reordered and grouped header includes in `src/lua_realpath.h` to separate Lua-specific, standard, and external headers, and removed unnecessary standard headers such as `fcntl.h`, `stdio.h`, `string.h`, `sys/stat.h`, `sys/types.h`, and `unistd.h`.
* Added `lauxhlib.h` as an external header in both `src/normalize.c` and `src/realpath.c`, and clarified header grouping for better readability. [[1]](diffhunk://#diff-ee19bd91de4ca58e271cf04d6789c2eccd5efcb68232677869484f87a306321bR25-R26) [[2]](diffhunk://#diff-c7297c97296f7bfd715dba87bc7470e6318af996f93e3def4b25bb68655527cdL23-R29)

Code clarity and maintainability:

* Improved code comments and formatting in the upvalue setup for the Lua C closure in `luaopen_realpath` to clarify the purpose of each upvalue.